### PR TITLE
fix(webpack): add babel polyfill for legacy browser support

### DIFF
--- a/packages/bcli/package.json
+++ b/packages/bcli/package.json
@@ -81,5 +81,8 @@
     "webpack-combine-loaders": "^2.0.3",
     "webpack-dev-server": "^2.2.0",
     "webpack-merge": "^2.3.1"
+  },
+  "devDependencies": {
+    "babel-polyfill": "^6.23.0"
   }
 }

--- a/packages/bcli/src/webpack/base.config.js
+++ b/packages/bcli/src/webpack/base.config.js
@@ -8,7 +8,10 @@ const rulesFolder = path.resolve(__dirname, './rules/')
 module.exports = {
   context: paths.appDirectory,
   entry: {
-    app: [paths.appEntry]
+    app: [
+      'babel-polyfill',
+      paths.appEntry
+    ]
   },
   output: {
     path: paths.appBuild,


### PR DESCRIPTION
Makes sure ES6 features work in legacy browsers as well, closes #12 