### PR TITLE
fix(bcli): invalid extract-text-webpack-plugin version

### DIFF
--- a/packages/bcli/package.json
+++ b/packages/bcli/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-standard": "^2.0.1",
     "eslint-plugin-vue": "^2.0.1",
     "execa": "^0.6.0",
-    "extract-text-webpack-plugin": "beta",
+    "extract-text-webpack-plugin": "2.0.0",
     "file-loader": "^0.10.0",
     "friendly-errors-webpack-plugin": "^1.1.2",
     "fs-extra": "^2.0.0",


### PR DESCRIPTION
Should fix this error when installing/updating
```
npm ERR! code ETARGET

npm ERR! notarget No compatible version found: extract-text-webpack-plugin@beta
npm ERR! notarget Valid install targets:
npm ERR! notarget 2.0.0, 2.0.0-rc.3, 2.0.0-rc.2, 2.0.0-rc.1, 2.0.0-rc.0, 2.0.0-beta.5, 2.0.0-beta.4, 2.0.0-beta.3, 2.0.0-beta.2, 2.0.0-beta.1, 2.0.0-beta.0, 1.0.1, 1.0.0, 0.9.1, 0.9.0, 0.8.2, 0.8.1, 0.8.0, 0.7.1, 0.7.0, 0.6.0, 0.5.0, 0.4.0, 0.3.8, 0.3.7, 0.3.6, 0.3.5, 0.3.4, 0.3.3, 0.3.2, 0.3.1, 0.3.0, 0.2.5, 0.2.4, 0.2.3, 0.2.2, 0.2.1, 0.2.0, 0.1.2, 0.1.1, 0.1.0
npm ERR! notarget
npm ERR! notarget This is most likely not a problem with npm itself.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
npm ERR! notarget
npm ERR! notarget It was specified as a dependency of 'bcli'
npm ERR! notarget
```