### PR TITLE
refactor(postcss): Refactor media queries. New grid, typography and v…

### DIFF
--- a/packages/blue-templates/src/pre-processor/postcss/compose/layout/grid.css
+++ b/packages/blue-templates/src/pre-processor/postcss/compose/layout/grid.css
@@ -190,157 +190,69 @@
 .space-around { justify-content: space-around; }
 .space-between { justify-content: space-between; }
 
+/**
+ * Gutters
+ *
+ * Using a transparent border combined with background-clip: padding-box
+ * enables you to use percentages on cols without the need to calc gutters
+ *
+ * Note: If you need a solid border around your column use an extra div
+ * inside the column.
+ *
+ * These styles should only be composed on
+ * the col
+ */
+.gutter {
+  background-clip: padding-box !important;
+  border-color: transparent !important;
+  border-style: solid;
+}
+
+/* Static gutters */
+.gut-xsmall { composes: gutter; border-width: 8px; }
+.gut-small { composes: gutter; border-width: 16px; }
+.gut-medium { composes: gutter; border-width: 24px; }
+.gut-large { composes: gutter; border-width: 32px; }
+
+/* Fluid gutters */
+.gut-fluid-xsmall { composes: gutter; border-width: 8vw; }
+.gut-fluid-small { composes: gutter; border-width: 1vw; }
+.gut-fluid-medium { composes: gutter; border-width: 2vw; }
+.gut-fluid-large { composes: gutter; border-width: 3vw; }
+
+/**
+ * Gutter fix
+ *
+ * Since every column gets a gutter the outside items are indented by default.
+ * This is fixable by applying a negative margin on the grid wrapper.
+ *
+ * These styles should only be composed on
+ * the flex-grid wrapper
+ */
+.gutfix { }
+
+.gutfix-xsmall { margin: -8px; }
+.gutfix-small { margin: -16px; }
+.gutfix-medium { margin: -24px; }
+.gutfix-large { margin: -32px; }
+
+/**
+ * Padding
+ *
+ * Same values as for gutter but then for inside the col. Use these to have
+ * consistent margins/paddigns accross your application.
+ *
+ * These styles should only be composed on
+ * the col
+ */
+.pad-xsmall { padding: 8px; }
+.pad-small { padding: 16px; }
+.pad-medium { padding: 24px; }
+.pad-large { padding: 32px; }
+
 /* ==========================================================================
    Breakpoints
    ========================================================================== */
-
-/**
- * Breakpoint: $xs
- *
- * These styles will be ignored on screens < $xs
- */
-@media ($xs) {
-  .col-xs-auto { flex: 1 0 auto; max-width: 100%; }
-  .col-xs-1-1 { flex: 1 0 100%; max-width: 100%; }
-  .col-xs-1-2 { flex: 1 0 50%; max-width: 50%; }
-  .col-xs-1-3 { flex: 1 0 33.33%; max-width: 33.33%; }
-  .col-xs-2-3 { flex: 1 0 66.66%; max-width: 66.66%; }
-  .col-xs-1-4 { flex: 1 0 25%; max-width: 25%; }
-  .col-xs-3-4 { flex: 1 0 75%; max-width: 75%; }
-  .col-xs-1-5 { flex: 1 0 20%; max-width: 20%; }
-  .col-xs-2-5 { flex: 1 0 40%; max-width: 40%; }
-  .col-xs-3-5 { flex: 1 0 60%; max-width: 60%; }
-  .col-xs-4-5 { flex: 1 0 80%; max-width: 80%; }
-  .col-xs-1-6 { flex: 1 0 16.66%; max-width: 16.66%; }
-  .col-xs-5-6 { flex: 1 0 83.33%; max-width: 83.33%; }
-  .col-xs-1-7 { flex: 1 0 14.28%; max-width: 14.28%; }
-  .col-xs-2-7 { flex: 1 0 28.57%; max-width: 28.57%; }
-  .col-xs-3-7 { flex: 1 0 42.86%; max-width: 42.86%; }
-  .col-xs-4-7 { flex: 1 0 57.14%; max-width: 57.14%; }
-  .col-xs-5-7 { flex: 1 0 71.43%; max-width: 71.43%; }
-  .col-xs-6-7 { flex: 1 0 85.71%; max-width: 85.71%; }
-  .col-xs-1-8 { flex: 1 0 12.5%; max-width: 12.5%; }
-  .col-xs-3-8 { flex: 1 0 37.5%; max-width: 37.5%; }
-  .col-xs-5-8 { flex: 1 0 62.5%; max-width: 62.5%; }
-  .col-xs-7-8 { flex: 1 0 87.5%; max-width: 87.5%; }
-  .col-xs-1-9 { flex: 1 0 11.11%; max-width: 11.11%; }
-  .col-xs-2-9 { flex: 1 0 22.22%; max-width: 22.22%; }
-  .col-xs-4-9 { flex: 1 0 44.44%; max-width: 44.44%; }
-  .col-xs-5-9 { flex: 1 0 55.55%; max-width: 55.55%; }
-  .col-xs-7-9 { flex: 1 0 77.77%; max-width: 77.77%; }
-  .col-xs-8-9 { flex: 1 0 88.88%; max-width: 88.88%; }
-  .col-xs-1-10 { flex: 1 0 10%; max-width: 10%; }
-  .col-xs-3-10 { flex: 1 0 30%; max-width: 30%; }
-  .col-xs-7-10 { flex: 1 0 70%; max-width: 70%; }
-  .col-xs-9-10 { flex: 1 0 90%; max-width: 90%; }
-  .col-xs-1-11 { flex: 1 0 9.09%; max-width: 9.09%; }
-  .col-xs-2-11 { flex: 1 0 18.18%; max-width: 18.18%; }
-  .col-xs-3-11 { flex: 1 0 27.27%; max-width: 27.27%; }
-  .col-xs-4-11 { flex: 1 0 36.36%; max-width: 36.36%; }
-  .col-xs-5-11 { flex: 1 0 45.45%; max-width: 45.45%; }
-  .col-xs-6-11 { flex: 1 0 54.54%; max-width: 54.54%; }
-  .col-xs-7-11 { flex: 1 0 63.63%; max-width: 63.63%; }
-  .col-xs-8-11 { flex: 1 0 72.72%; max-width: 72.72%; }
-  .col-xs-9-11 { flex: 1 0 81.81%; max-width: 81.81%; }
-  .col-xs-10-11 { flex: 1 0 90.90%; max-width: 90.90%; }
-  .col-xs-1-12 { flex: 1 0 8.33%; max-width: 8.33%; }
-  .col-xs-5-12 { flex: 1 0 41.66%; max-width: 41.66%; }
-  .col-xs-7-12 { flex: 1 0 58.33%; max-width: 58.33%; }
-  .col-xs-11-12 { flex: 1 0 91.66%; max-width: 91.66%; }
-
-  /**
-   * Push
-   *
-   * Push columns to the right based on col width.
-   */
-  .push-xs-auto { margin-left: auto; }
-  .push-xs-1-1 { margin-left: 100%; }
-  .push-xs-1-2 { margin-left: 50%; }
-  .push-xs-1-3 { margin-left: 33.33%; }
-  .push-xs-2-3 { margin-left: 66.66%; }
-  .push-xs-1-4 { margin-left: 25%; }
-  .push-xs-3-4 { margin-left: 75%; }
-  .push-xs-1-5 { margin-left: 20%; }
-  .push-xs-2-5 { margin-left: 40%; }
-  .push-xs-3-5 { margin-left: 60%; }
-  .push-xs-4-5 { margin-left: 80%; }
-  .push-xs-1-6 { margin-left: 16.66%; }
-  .push-xs-5-6 { margin-left: 83.33%; }
-  .push-xs-1-7 { margin-left: 14.28%; }
-  .push-xs-2-7 { margin-left: 28.57%; }
-  .push-xs-3-7 { margin-left: 42.86%; }
-  .push-xs-4-7 { margin-left: 57.14%; }
-  .push-xs-5-7 { margin-left: 71.43%; }
-  .push-xs-6-7 { margin-left: 85.71%; }
-  .push-xs-1-8 { margin-left: 12.5%; }
-  .push-xs-3-8 { margin-left: 37.5%; }
-  .push-xs-5-8 { margin-left: 62.5%; }
-  .push-xs-7-8 { margin-left: 87.5%; }
-  .push-xs-1-9 { margin-left: 11.11%; }
-  .push-xs-2-9 { margin-left: 22.22%; }
-  .push-xs-4-9 { margin-left: 44.44%; }
-  .push-xs-5-9 { margin-left: 55.55%; }
-  .push-xs-7-9 { margin-left: 77.77%; }
-  .push-xs-8-9 { margin-left: 88.88%; }
-  .push-xs-1-10 { margin-left: 10%; }
-  .push-xs-3-10 { margin-left: 30%; }
-  .push-xs-7-10 { margin-left: 70%; }
-  .push-xs-9-10 { margin-left: 90%; }
-  .push-xs-1-11 { margin-left: 9.09%; }
-  .push-xs-2-11 { margin-left: 18.18%; }
-  .push-xs-3-11 { margin-left: 27.27%; }
-  .push-xs-4-11 { margin-left: 36.36%; }
-  .push-xs-5-11 { margin-left: 45.45%; }
-  .push-xs-6-11 { margin-left: 54.54%; }
-  .push-xs-7-11 { margin-left: 63.63%; }
-  .push-xs-8-11 { margin-left: 72.72%; }
-  .push-xs-9-11 { margin-left: 81.81%; }
-  .push-xs-10-11 { margin-left: 90.90%; }
-  .push-xs-1-12 { margin-left: 8.33%; }
-  .push-xs-5-12 { margin-left: 41.66%; }
-  .push-xs-7-12 { margin-left: 58.33%; }
-  .push-xs-11-12 { margin-left: 91.66%; }
-
-  /**
-   * Align items
-   *
-   * Vertical alignment.
-   *
-   * These styles should only be composed on
-   * the flex-grid wrapper
-   */
-  .align-xs-top { align-items: flex-start; }
-  .align-xs-middle { align-items: center; }
-  .align-xs-bottom { align-items: flex-end; }
-
-  /* Horizontal alignment */
-  .align-xs-left { justify-content: flex-start; }
-  .align-xs-center { justify-content: center; }
-  .align-xs-right { justify-content: flex-end; }
-
-  /**
-   * Align self
-   *
-   * Col alignment exceptions
-   *
-   * These styles should only be composed on
-   * the col
-   */
-  .align-xs-self-top { align-self: flex-start; }
-  .align-xs-self-middle { align-self: center; }
-  .align-xs-self-bottom { align-self: flex-end; }
-
-  /**
-   * Distribution
-   *
-   * Fill empty space around or between cols
-   *
-   * These styles should only be composed on
-   * the flex-grid wrapper
-   */
-  .space-xs-around { justify-content: space-around; }
-  .space-xs-between { justify-content: space-between; }
-}
 
 /**
  * Breakpoint: $s
@@ -487,6 +399,66 @@
    */
   .space-s-around { justify-content: space-around; }
   .space-s-between { justify-content: space-between; }
+
+  /**
+   * Gutters
+   *
+   * Using a transparent border combined with background-clip: padding-box
+   * enables you to use percentages on cols without the need to calc gutters
+   *
+   * Note: If you need a solid border around your column use an extra div
+   * inside the column.
+   *
+   * These styles should only be composed on
+   * the col
+   */
+  .s-gutter {
+    background-clip: padding-box !important;
+    border-color: transparent !important;
+    border-style: solid;
+  }
+
+  /* Static gutters */
+  .gut-s-xsmall { composes: gutter; border-width: 8px; }
+  .gut-s-small { composes: gutter; border-width: 16px; }
+  .gut-s-medium { composes: gutter; border-width: 24px; }
+  .gut-s-large { composes: gutter; border-width: 32px; }
+
+  /* Fluid gutters */
+  .gut-s-fluid-xsmall { composes: gutter; border-width: 8px; }
+  .gut-s-fluid-small { composes: gutter; border-width: 1vw; }
+  .gut-s-fluid-medium { composes: gutter; border-width: 2vw; }
+  .gut-s-fluid-large { composes: gutter; border-width: 3vw; }
+
+  /**
+   * Gutter fix
+   *
+   * Since every column gets a gutter the outside items are indented by default.
+   * This is fixable by applying a negative margin on the grid wrapper.
+   *
+   * These styles should only be composed on
+   * the flex-grid wrapper
+   */
+  .gutfix { }
+
+  .gutfix-s-xsmall { margin: -8px; }
+  .gutfix-s-small { margin: -16px; }
+  .gutfix-s-medium { margin: -24px; }
+  .gutfix-s-large { margin: -32px; }
+
+  /**
+   * Padding
+   *
+   * Same values as for gutter but then for inside the col. Use these to have
+   * consistent margins/paddigns accross your application.
+   *
+   * These styles should only be composed on
+   * the col
+   */
+  .pad-s-xsmall { padding: 8px; }
+  .pad-s-small { padding: 16px; }
+  .pad-s-medium { padding: 24px; }
+  .pad-s-large { padding: 32px; }
 }
 
 /**
@@ -634,6 +606,66 @@
    */
   .space-m-around { justify-content: space-around; }
   .space-m-between { justify-content: space-between; }
+
+  /**
+   * Gutters
+   *
+   * Using a transparent border combined with background-clip: padding-box
+   * enables you to use percentages on cols without the need to calc gutters
+   *
+   * Note: If you need a solid border around your column use an extra div
+   * inside the column.
+   *
+   * These styles should only be composed on
+   * the col
+   */
+  .m-gutter {
+    background-clip: padding-box !important;
+    border-color: transparent !important;
+    border-style: solid;
+  }
+
+  /* Static gutters */
+  .gut-m-xsmall { composes: gutter; border-width: 8px; }
+  .gut-m-small { composes: gutter; border-width: 16px; }
+  .gut-m-medium { composes: gutter; border-width: 24px; }
+  .gut-m-large { composes: gutter; border-width: 32px; }
+
+  /* Fluid gutters */
+  .gut-m-fluid-xsmall { composes: gutter; border-width: 8px; }
+  .gut-m-fluid-small { composes: gutter; border-width: 1vw; }
+  .gut-m-fluid-medium { composes: gutter; border-width: 2vw; }
+  .gut-m-fluid-large { composes: gutter; border-width: 3vw; }
+
+  /**
+   * Gutter fix
+   *
+   * Since every column gets a gutter the outside items are indented by default.
+   * This is fixable by applying a negative margin on the grid wrapper.
+   *
+   * These styles should only be composed on
+   * the flex-grid wrapper
+   */
+  .m-gutfix { }
+
+  .gutfix-m-xsmall { margin: -8px; }
+  .gutfix-m-small { margin: -16px; }
+  .gutfix-m-medium { margin: -24px; }
+  .gutfix-m-large { margin: -32px; }
+
+  /**
+   * Padding
+   *
+   * Same values as for gutter but then for inside the col. Use these to have
+   * consistent margins/paddigns accross your application.
+   *
+   * These styles should only be composed on
+   * the col
+   */
+  .pad-m-xsmall { padding: 8px; }
+  .pad-m-small { padding: 16px; }
+  .pad-m-medium { padding: 24px; }
+  .pad-m-large { padding: 32px; }
 }
 
 /**
@@ -781,6 +813,66 @@
    */
   .space-l-around { justify-content: space-around; }
   .space-l-between { justify-content: space-between; }
+
+  /**
+   * Gutters
+   *
+   * Using a transparent border combined with background-clip: padding-box
+   * enables you to use percentages on cols without the need to calc gutters
+   *
+   * Note: If you need a solid border around your column use an extra div
+   * inside the column.
+   *
+   * These styles should only be composed on
+   * the col
+   */
+  .l-gutter {
+    background-clip: padding-box !important;
+    border-color: transparent !important;
+    border-style: solid;
+  }
+
+  /* Static gutters */
+  .gut-l-xsmall { composes: gutter; border-width: 8px; }
+  .gut-l-small { composes: gutter; border-width: 16px; }
+  .gut-l-medium { composes: gutter; border-width: 24px; }
+  .gut-l-large { composes: gutter; border-width: 32px; }
+
+  /* Fluid gutters */
+  .gut-l-fluid-xsmall { composes: gutter; border-width: 8px; }
+  .gut-l-fluid-small { composes: gutter; border-width: 1vw; }
+  .gut-l-fluid-medium { composes: gutter; border-width: 2vw; }
+  .gut-l-fluid-large { composes: gutter; border-width: 3vw; }
+
+  /**
+   * Gutter fix
+   *
+   * Since every column gets a gutter the outside items are indented by default.
+   * This is fixable by applying a negative margin on the grid wrapper.
+   *
+   * These styles should only be composed on
+   * the flex-grid wrapper
+   */
+  .l-gutfix { }
+
+  .gutfix-l-xsmall { margin: -8px; }
+  .gutfix-l-small { margin: -16px; }
+  .gutfix-l-medium { margin: -24px; }
+  .gutfix-l-large { margin: -32px; }
+
+  /**
+   * Padding
+   *
+   * Same values as for gutter but then for inside the col. Use these to have
+   * consistent margins/paddigns accross your application.
+   *
+   * These styles should only be composed on
+   * the col
+   */
+  .pad-l-xsmall { padding: 8px; }
+  .pad-l-small { padding: 16px; }
+  .pad-l-medium { padding: 24px; }
+  .pad-l-large { padding: 32px; }
 }
 
 /**
@@ -928,4 +1020,64 @@
    */
   .space-xl-around { justify-content: space-around; }
   .space-xl-between { justify-content: space-between; }
+
+  /**
+   * Gutters
+   *
+   * Using a transparent border combined with background-clip: padding-box
+   * enables you to use percentages on cols without the need to calc gutters
+   *
+   * Note: If you need a solid border around your column use an extra div
+   * inside the column.
+   *
+   * These styles should only be composed on
+   * the col
+   */
+  .xl-gutter {
+    background-clip: padding-box !important;
+    border-color: transparent !important;
+    border-style: solid;
+  }
+
+  /* Static gutters */
+  .gut-xl-xsmall { composes: gutter; border-width: 8px; }
+  .gut-xl-small { composes: gutter; border-width: 16px; }
+  .gut-xl-medium { composes: gutter; border-width: 24px; }
+  .gut-xl-large { composes: gutter; border-width: 32px; }
+
+  /* Fluid gutters */
+  .gut-xl-fluid-xsmall { composes: gutter; border-width: 8px; }
+  .gut-xl-fluid-small { composes: gutter; border-width: 1vw; }
+  .gut-xl-fluid-medium { composes: gutter; border-width: 2vw; }
+  .gut-xl-fluid-large { composes: gutter; border-width: 3vw; }
+
+  /**
+   * Gutter fix
+   *
+   * Since every column gets a gutter the outside items are indented by default.
+   * This is fixable by applying a negative margin on the grid wrapper.
+   *
+   * These styles should only be composed on
+   * the flex-grid wrapper
+   */
+  .xl-gutfix { }
+
+  .gutfix-xl-xsmall { margin: -8px; }
+  .gutfix-xl-small { margin: -16px; }
+  .gutfix-xl-medium { margin: -24px; }
+  .gutfix-xl-large { margin: -32px; }
+
+  /**
+   * Padding
+   *
+   * Same values as for gutter but then for inside the col. Use these to have
+   * consistent margins/paddigns accross your application.
+   *
+   * These styles should only be composed on
+   * the col
+   */
+  .pad-xl-xsmall { padding: 8px; }
+  .pad-xl-small { padding: 16px; }
+  .pad-xl-medium { padding: 24px; }
+  .pad-xl-large { padding: 32px; }
 }

--- a/packages/blue-templates/src/pre-processor/postcss/compose/layout/visibility.css
+++ b/packages/blue-templates/src/pre-processor/postcss/compose/layout/visibility.css
@@ -1,0 +1,128 @@
+/* ==========================================================================
+   Visibility
+   ========================================================================== */
+
+/**
+ * This file contains visibility classes. Use these to show/hide content based
+ * on viewport width.
+ *
+ * There are 2 types of visible classes:
+ *
+ * 1) .${size}-iso-${type}
+ * This will only show on the specified (isolated) ${size}
+ *
+ * 2) .${size}-${type}
+ * This will show on the specified ${size} and above
+ */
+
+ /* Block (1)
+    ========================================================================== */
+.xsmall-iso-block {
+  display: block;
+  @media ($s) { display: none; }
+}
+
+.small-iso-block {
+  display: none;
+  @media ($s) { display: block; }
+  @media ($m) { display: none; }
+}
+
+.medium-iso-block {
+  display: none;
+  @media ($m) { display: block; }
+  @media ($l) { display: none; }
+}
+
+.large-iso-block {
+  display: none;
+  @media ($l) { display: block; }
+  @media ($xl) { display: none; }
+}
+
+.xlarge-iso-block {
+  display: none;
+  @media ($xl) { display: block; }
+}
+
+/* Inline block
+   ========================================================================== */
+.xsmall-iso-inline {
+ display: inline-block;
+ @media ($s) { display: none; }
+}
+
+.small-iso-inline {
+ display: none;
+ @media ($s) { display: inline-block; }
+ @media ($m) { display: none; }
+}
+
+.medium-iso-inline {
+ display: none;
+ @media ($m) { display: inline-block; }
+ @media ($l) { display: none; }
+}
+
+.large-iso-inline {
+ display: none;
+ @media ($l) { display: inline-block; }
+ @media ($xl) { display: none; }
+}
+
+.xlarge-iso-inline {
+ display: none;
+ @media ($xl) { display: inline-block; }
+}
+
+/* Block (2)
+   ========================================================================== */
+.xsmall-block {
+  display: block;
+}
+
+.small-block {
+  display: none;
+  @media ($s) { display: block; }
+}
+
+.medium-block {
+  display: none;
+  @media ($m) { display: block; }
+}
+
+.large-block {
+  display: none;
+  @media ($l) { display: block; }
+}
+
+.xlarge-block {
+  display: none;
+  @media ($xl) { display: block; }
+}
+
+/* Inline block (2)
+   ========================================================================== */
+.xsmall-inline {
+  display: inline-block;
+}
+
+.small-inline {
+  display: none;
+  @media ($s) { display: inline-block; }
+}
+
+.medium-inline {
+  display: none;
+  @media ($m) { display: inline-block; }
+}
+
+.large-inline {
+  display: none;
+  @media ($l) { display: inline-block; }
+}
+
+.xlarge-inline {
+  display: none;
+  @media ($xl) { display: inline-block; }
+}

--- a/packages/blue-templates/src/pre-processor/postcss/compose/type/heading.css
+++ b/packages/blue-templates/src/pre-processor/postcss/compose/type/heading.css
@@ -7,27 +7,13 @@
  *
  * This file contains all titles and subtitles used across pages/components. Combine
  * composes from typography.css to create headings.
- */
-
-/**
- * Default heading styles
  *
- * Every heading composes this style. This could be useful for debugging
- * purposes or general heading styles.
+ * Try to limit the max amount of headings to 6 (h1-h6). If you need more talk to
+ * the designer to see if some headings can be merged.
  */
-.heading {
-
-}
-
-/**
- * Heading 1
- *
- * Short description of this heading
- *
- * 1. When to use
- * 2. Where to use
- */
-.heading-1 {
-  composes: heading;
-  composes: verdana medium from $typography;
-}
+.heading-1 { composes: pt-sans h-xxlarge from $typography; }
+.heading-2 { composes: pt-sans h-xlarge from $typography; }
+.heading-3 { composes: pt-sans h-large from $typography; }
+.heading-4 { composes: pt-sans h-medium from $typography; }
+.heading-5 { composes: pt-sans h-small from $typography; }
+.heading-6 { composes: pt-sans h-xsmall from $typography; }

--- a/packages/blue-templates/src/pre-processor/postcss/compose/type/type.css
+++ b/packages/blue-templates/src/pre-processor/postcss/compose/type/type.css
@@ -8,26 +8,14 @@
  * This file contains all type styles used across pages/components. Combine
  * composes from typography.css to create type styles.
  */
-
-/**
- * Default type styles
- *
- * Every type composes this style. This could be useful for debugging
- * purposes or general type styles.
- */
-.type {
-
+.type-1 {
+  composes: pt-sans large from $typography;
 }
 
-/**
- * Type 1
- *
- * Short description of this type
- *
- * 1. When to use
- * 2. Where to use
- */
-.type-1 {
-  composes: type;
-  composes: verdana medium from $typography;
+.type-2 {
+  composes: pt-sans medium from $typography;
+}
+
+.type-3 {
+  composes: pt-sans small from $typography;
 }

--- a/packages/blue-templates/src/pre-processor/postcss/compose/type/typography.css
+++ b/packages/blue-templates/src/pre-processor/postcss/compose/type/typography.css
@@ -1,6 +1,7 @@
 /* ==========================================================================
    Typography
    ========================================================================== */
+@import url('https://fonts.googleapis.com/css?family=PT+Sans');
 
 /**
  * Fonts, sizes and text colors
@@ -12,14 +13,47 @@
  * heading.css or type.css to use instead.
 */
 
-
 /* Font families
    ========================================================================== */
-.verdana { font-family: Verdana, sans-serif; }
+.pt-sans { font-family: 'PT Sans', sans-serif; }
 
 /* Font sizes
    ========================================================================== */
-.medium { font-size: 1.8rem; }
+
+/* Heading sizes */
+.h-xsmall { font-size: 1.2rem; }
+.h-small { font-size: 1.4rem; }
+.h-medium { font-size: 1.8rem; }
+.h-large { font-size: 2.4rem; }
+.h-xlarge { font-size: 3rem; }
+.h-xxlarge { font-size: 3.6rem; }
+
+/* Type sizes */
+.small { font-size: 1.2rem; line-height: 1.428em; }
+.medium { font-size: 1.4rem; line-height: 1.428em; }
+.large { font-size: 1.6rem; line-height: 1.428em; }
+
+/**
+ * Small
+ *
+ * Create lighter, secondary text in any heading/type with a
+ * generic <small> tag.
+ */
+.h-xsmall, .h-small, .h-medium, .h-large, .h-xlarge, .h-xxlarge,
+.small, .medium, .large {
+  small {
+    font-size: 0.65em;
+  }
+}
+
+/**
+ * Font size breakpoints
+ *
+ * Handle all device specific font sizes here
+*/
+@media ($m) {
+  /*.h-xxlarge { font-size: 5rem; }*/
+}
 
 /* Transforms
    ========================================================================== */

--- a/packages/blue-templates/src/pre-processor/postcss/compose/ui/button.css
+++ b/packages/blue-templates/src/pre-processor/postcss/compose/ui/button.css
@@ -18,8 +18,17 @@
 /**
  * Primary button
  *
- * Main Call to action
+ * Default button styles. This button comes with 3 sizes.
+ * Default, small and large. Based on font-size
  */
-.primary {
+.primary-base {
   composes: button;
+  padding: 1em;
+  background: #333;
+  border-radius: 10px;
+  color: #fff;
 }
+
+.primary { composes: primary-base; composes: type2 from $type; }
+.primary-small { composes: primary-base; composes: type3 from $type; }
+.primary-large { composes: primary-base; composes: type1 from $type; }

--- a/packages/blue-templates/src/pre-processor/postcss/config/mediaQueries.js
+++ b/packages/blue-templates/src/pre-processor/postcss/config/mediaQueries.js
@@ -1,21 +1,15 @@
-const mobileFirst = true
+const mediaQueries = {
+  /* Small devices (tablets, 768px and up) */
+  's': 'min-width: 769px',
 
-let mediaQueries = {
-  'xs': 'max-width: 480px',
-  's': 'max-width: 768px',
-  'm': 'max-width: 1024px',
-  'l': 'min-width: 1025px',
-  'xl': 'min-width: 1480px'
-}
+  /* Medium devices (desktops, 992px and up) */
+  'm': 'min-width: 992px',
 
-if (mobileFirst) {
-  mediaQueries = {
-    'xs': 'min-width: 469px',
-    's': 'min-width: 769px',
-    'm': 'min-width: 1025px',
-    'l': 'min-width: 1201px',
-    'xl': 'min-width: 1440px'
-  }
+  /* Large devices (large desktops, 1200px and up) */
+  'l': 'min-width: 1200px',
+
+  /* Extra Large devices (x-large desktops (imac), 1440px and up) */
+  'xl': 'min-width: 1440px'
 }
 
 module.exports = mediaQueries

--- a/packages/blue-templates/src/pre-processor/postcss/config/variables.js
+++ b/packages/blue-templates/src/pre-processor/postcss/config/variables.js
@@ -9,6 +9,7 @@ const paths = {
   'common': utils.getComposeFile('common.css'),
   'page': utils.getComposeFile('layout/page.css'),
   'grid': utils.getComposeFile('layout/grid.css'),
+  'visibility': utils.getComposeFile('layout/visibility.css'),
   'button': utils.getComposeFile('ui/button.css'),
   'list': utils.getComposeFile('ui/list.css'),
   'icon': utils.getComposeFile('ui/icon.css'),


### PR DESCRIPTION
# Better mediaqueries
- Small devices (tablets, 768px and up)
- Medium devices (desktops, 992px and up)
- Large devices (large desktops, 1200px and up)
- Extra Large devices (x-large desktops (imac), 1440px and up)

# Visibility classes
Use these to show/hide content based on viewport width. There are 2 types of visible classes:

## 1) .${size}-iso-${type}
This will only show on the specified (isolated) ${size}

## 2) .${size}-${type}
This will show on the specified ${size} and above

# Headings
Six default headings. Every heading also has a <small> tag which will set the font-size to 65% of the original heading. Example:

```html
<h1 :class="$style.heading">I am 36px</h1>
<h1 :class="$style.heading"><small>I am 23.4px</small></h1>
```

# Type
Default types, same rules as for headings.

# Grid improvements
- Added gutters.
- Added paddings.